### PR TITLE
mulfrac: support non-frac types

### DIFF
--- a/src/ClockNode.zig
+++ b/src/ClockNode.zig
@@ -261,7 +261,7 @@ pub const ClockNode = struct {
 
     fn mulfrac(self: Self, node: *const MulFrac) ClockState {
         if (self.parents) |parents| {
-            if (parents.len > 2) {
+            if (parents.len >= 2) {
                 const value = node.value;
                 const limit = self.limit_check(value, node.limit);
                 switch (limit) {
@@ -271,7 +271,11 @@ pub const ClockNode = struct {
 
                         switch (frac) {
                             .Ok => |from_frac| {
-                                const frac_max = parents[1].Nodetype.frac.max;
+                                const frac_max = switch (parents[1].Nodetype) {
+                                    .frac => |f| f.max,
+                                    .source => |s| s.limit.?.max,
+                                    else => return .{ .NoParent = .{ .node = self } },
+                                };
                                 switch (input) {
                                     .Ok => |from_input| {
                                         return .{ .Ok = node.get(


### PR DESCRIPTION
The current implementation fails to init_compile `SysClkOutput`. The problem is with calculating `DIVN1`. For `STM32H750IB` chips, `DIVN1` has only 2 parents, and `PLLFRACN` is a `source` type. 

```
        const DIVM1val = ClockNodeTypes{
            .div = .{},
        };

        const PLLFRACNval = ClockNodeTypes{
            .source = .{},
        };

        const DIVN1val = ClockNodeTypes{
            .mulfrac = .{},
        };
        const DIVN1: ClockNode = .{
            .name = "DIVN1",
            .Nodetype = DIVN1val,
            .parents = &[_]*const ClockNode{ &DIVM1, &PLLFRACN },
        };
```
